### PR TITLE
test(typecheck): add basic "happy path" type test

### DIFF
--- a/.github/workflows/type_check.yaml
+++ b/.github/workflows/type_check.yaml
@@ -1,0 +1,32 @@
+name: Type Check
+permissions:
+  contents: read
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  type-check:
+    name: Run TypeScript Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npx tsc --noEmit
+        # This will fail the workflow if there are type errors

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/gleanwork/api-client-typescript.git"
   },
   "scripts": {
-    "test": "vitest run src --reporter=junit --outputFile=.speakeasy/reports/tests.xml --reporter=default",
+    "test": "vitest run src --typecheck --reporter=junit --outputFile=.speakeasy/reports/tests.xml --reporter=default",
     "check": "npm run test && npm run lint",
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tshy",

--- a/src/__tests__/indexing.test-d.ts
+++ b/src/__tests__/indexing.test-d.ts
@@ -1,0 +1,40 @@
+import { expectTypeOf, test } from "vitest";
+import { Glean } from "../index.js";
+
+test("type test for `Glean` constructor", () => {
+  // @ts-expect-error - Function is defined but never used (only for type checking)
+  async function run() {
+    const glean = new Glean({
+      apiToken: process.env["GLEAN_API_TOKEN"],
+      instance: process.env["GLEAN_INSTANCE"],
+    });
+
+    const response = await glean.indexing.documents.index({
+      datasource: "my-datasource",
+      documents: [
+        {
+          datasource: "my-datasource",
+          id: "doc-123",
+          title: "Sample Document",
+          body: {
+            mimeType: "text/plain",
+            textContent: "This is a sample document to index in Glean.",
+          },
+          viewURL: "https://example.com/documents/123",
+          permissions: {
+            allowedUsers: [{ email: "user@example.com" }],
+            allowedGroups: ["everyone@example.com"],
+          },
+        },
+      ],
+    });
+
+    return response;
+  }
+  
+  const correctClient = new Glean({
+    apiToken: "token",
+    instance: "example-instance",
+  });
+  expectTypeOf(correctClient).toEqualTypeOf<Glean>();
+});


### PR DESCRIPTION
With 0.4.1 this failed like:

```typescript
src/__tests__/indexing.test-d.ts(8,7): error TS2353: Object literal may only specify known properties, and 'apiToken' does not exist in type 'SDKOptions'.
src/__tests__/indexing.test-d.ts(36,5): error TS2353: Object literal may only specify known properties, and 'apiToken' does not exist in type 'SDKOptions'.
```