### PR TITLE
fix(examples): Add `build:examples` npm script

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -6,7 +6,8 @@
   "main": "main.js",
   "scripts": {
     "script": "tsx",
-    "start": "npm run script -- ./src/example.ts"
+    "start": "npm run script -- ./src/example.ts",
+    "build:examples": "npm i"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This is the last blocker to bumping our generation to the latest Speakeasy CLI version. 

The latest version of `speakeasy` requires there to be a `build:examples` script in `examples/package.json`. This is likely a bug, because during `speakeasy run` it *adds* the `build:examples` script (along with a number of other changes to
`examples/package.json`).