### PR TITLE
ci: use Node 24 for npm 11

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 "aqua:speakeasy-api/speakeasy" = "latest"
 # used to run the mockserver
 go = "1.22"
-node = "20"
+node = "24"


### PR DESCRIPTION
**BLUF:** CI now uses Node 24 so npm 11 validates Speakeasy-generated lockfiles.

Speakeasy generation currently runs in its action container with Node 24/npm 11, while this repo's CI was still pinned to Node 20/npm 10. npm 10 rejects the package-lock format produced by npm 11 for the current Vite/Vitest dependency graph, causing regenerated SDK PRs to fail during `npm ci` before tests or typecheck run.

### Details

This updates `mise.toml` from Node 20 to Node 24. Node 20 is EOL, and Node 24 is the current Active LTS line. This also aligns CI with the Speakeasy generation container's npm 11 behavior.

I targeted `main` for this PR because this repository does not have a `master` branch.

### Validation

```bash
MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec -- bash -lc 'node --version && npm --version && npm ci --ignore-scripts && npx tsc --noEmit'
```

Validated locally with Node 24.14.0 and npm 11.9.0.
