### PR TITLE
fix: emit X-Glean-Include-Experimental header (not X-Glean-Experimental)

### DIFF
--- a/src/__tests__/x-glean.test.ts
+++ b/src/__tests__/x-glean.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { XGlean } from "../hooks/x-glean.js";
+import {
+  XGlean,
+  EXCLUDE_DEPRECATED_AFTER_HEADER,
+  INCLUDE_EXPERIMENTAL_HEADER,
+} from "../hooks/x-glean.js";
 import { BeforeRequestContext } from "../hooks/types.js";
 import { SDKOptions } from "../lib/config.js";
 import { XGleanOptions } from "../hooks/x-glean-options.js";
@@ -46,10 +50,10 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Exclude-Deprecated-After")).toBe(
+      expect(result.headers.has(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(
         false,
       );
-      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
+      expect(result.headers.has(INCLUDE_EXPERIMENTAL_HEADER)).toBe(false);
     });
   });
 
@@ -63,7 +67,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
+      expect(result.headers.get(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(
         "2026-10-15",
       );
     });
@@ -77,7 +81,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
+      expect(result.headers.get(INCLUDE_EXPERIMENTAL_HEADER)).toBe("true");
     });
 
     it("should not set X-Glean-Include-Experimental header when includeExperimental is false", () => {
@@ -89,7 +93,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
+      expect(result.headers.has(INCLUDE_EXPERIMENTAL_HEADER)).toBe(false);
     });
 
     it("should set both headers when both options are provided", () => {
@@ -102,10 +106,10 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
+      expect(result.headers.get(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(
         "2026-10-15",
       );
-      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
+      expect(result.headers.get(INCLUDE_EXPERIMENTAL_HEADER)).toBe("true");
     });
   });
 
@@ -119,7 +123,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
+      expect(result.headers.get(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(
         "2027-01-01",
       );
     });
@@ -133,7 +137,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
+      expect(result.headers.get(INCLUDE_EXPERIMENTAL_HEADER)).toBe("true");
     });
 
     it("should set both headers from environment variables", () => {
@@ -146,10 +150,10 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
+      expect(result.headers.get(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(
         "2027-06-15",
       );
-      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
+      expect(result.headers.get(INCLUDE_EXPERIMENTAL_HEADER)).toBe("true");
     });
 
     it("should not set X-Glean-Include-Experimental header when environment variable is false", () => {
@@ -163,7 +167,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
+      expect(result.headers.has(INCLUDE_EXPERIMENTAL_HEADER)).toBe(false);
     });
 
     it("should fall back to SDK options when experimental env var is empty", () => {
@@ -177,7 +181,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
+      expect(result.headers.get(INCLUDE_EXPERIMENTAL_HEADER)).toBe("true");
     });
   });
 
@@ -193,7 +197,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
+      expect(result.headers.get(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(
         "2027-12-31",
       );
     });
@@ -209,7 +213,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
+      expect(result.headers.get(INCLUDE_EXPERIMENTAL_HEADER)).toBe("true");
     });
 
     it("should use environment variables for both headers when all are set", () => {
@@ -225,10 +229,10 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
+      expect(result.headers.get(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(
         "2028-01-01",
       );
-      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
+      expect(result.headers.get(INCLUDE_EXPERIMENTAL_HEADER)).toBe("true");
     });
 
     it("should omit X-Glean-Include-Experimental header when env var is false, even if option is true", () => {
@@ -242,7 +246,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
+      expect(result.headers.has(INCLUDE_EXPERIMENTAL_HEADER)).toBe(false);
     });
   });
 
@@ -256,7 +260,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Exclude-Deprecated-After")).toBe(false);
+      expect(result.headers.has(EXCLUDE_DEPRECATED_AFTER_HEADER)).toBe(false);
     });
   });
 });

--- a/src/__tests__/x-glean.test.ts
+++ b/src/__tests__/x-glean.test.ts
@@ -49,7 +49,7 @@ describe("XGlean hook", () => {
       expect(result.headers.has("X-Glean-Exclude-Deprecated-After")).toBe(
         false,
       );
-      expect(result.headers.has("X-Glean-Experimental")).toBe(false);
+      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
     });
   });
 
@@ -68,7 +68,7 @@ describe("XGlean hook", () => {
       );
     });
 
-    it("should set X-Glean-Experimental header when includeExperimental is true", () => {
+    it("should set X-Glean-Include-Experimental header when includeExperimental is true", () => {
       const hook = new XGlean();
       const request = createMockRequest();
       const context = createMockContext({
@@ -77,10 +77,10 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Experimental")).toBe("true");
+      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
     });
 
-    it("should not set X-Glean-Experimental header when includeExperimental is false", () => {
+    it("should not set X-Glean-Include-Experimental header when includeExperimental is false", () => {
       const hook = new XGlean();
       const request = createMockRequest();
       const context = createMockContext({
@@ -89,7 +89,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Experimental")).toBe(false);
+      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
     });
 
     it("should set both headers when both options are provided", () => {
@@ -105,7 +105,7 @@ describe("XGlean hook", () => {
       expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
         "2026-10-15",
       );
-      expect(result.headers.get("X-Glean-Experimental")).toBe("true");
+      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
     });
   });
 
@@ -124,7 +124,7 @@ describe("XGlean hook", () => {
       );
     });
 
-    it("should set X-Glean-Experimental header from environment variable", () => {
+    it("should set X-Glean-Include-Experimental header from environment variable", () => {
       process.env["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "true";
 
       const hook = new XGlean();
@@ -133,7 +133,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Experimental")).toBe("true");
+      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
     });
 
     it("should set both headers from environment variables", () => {
@@ -149,10 +149,10 @@ describe("XGlean hook", () => {
       expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
         "2027-06-15",
       );
-      expect(result.headers.get("X-Glean-Experimental")).toBe("true");
+      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
     });
 
-    it("should not set X-Glean-Experimental header when environment variable is false", () => {
+    it("should not set X-Glean-Include-Experimental header when environment variable is false", () => {
       process.env["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "false";
 
       const hook = new XGlean();
@@ -163,7 +163,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Experimental")).toBe(false);
+      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
     });
 
     it("should fall back to SDK options when experimental env var is empty", () => {
@@ -177,7 +177,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Experimental")).toBe("true");
+      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
     });
   });
 
@@ -209,7 +209,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.get("X-Glean-Experimental")).toBe("true");
+      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
     });
 
     it("should use environment variables for both headers when all are set", () => {
@@ -228,10 +228,10 @@ describe("XGlean hook", () => {
       expect(result.headers.get("X-Glean-Exclude-Deprecated-After")).toBe(
         "2028-01-01",
       );
-      expect(result.headers.get("X-Glean-Experimental")).toBe("true");
+      expect(result.headers.get("X-Glean-Include-Experimental")).toBe("true");
     });
 
-    it("should omit X-Glean-Experimental header when env var is false, even if option is true", () => {
+    it("should omit X-Glean-Include-Experimental header when env var is false, even if option is true", () => {
       process.env["X_GLEAN_INCLUDE_EXPERIMENTAL"] = "false";
 
       const hook = new XGlean();
@@ -242,7 +242,7 @@ describe("XGlean hook", () => {
 
       const result = hook.beforeRequest(context, request);
 
-      expect(result.headers.has("X-Glean-Experimental")).toBe(false);
+      expect(result.headers.has("X-Glean-Include-Experimental")).toBe(false);
     });
   });
 

--- a/src/hooks/x-glean.ts
+++ b/src/hooks/x-glean.ts
@@ -1,5 +1,8 @@
 import { BeforeRequestContext, BeforeRequestHook } from "./types.js";
 
+export const EXCLUDE_DEPRECATED_AFTER_HEADER = "X-Glean-Exclude-Deprecated-After";
+export const INCLUDE_EXPERIMENTAL_HEADER = "X-Glean-Include-Experimental";
+
 /**
  * Get the first non-empty value from the provided arguments.
  */
@@ -60,11 +63,11 @@ export class XGlean implements BeforeRequestHook {
     }
 
     if (deprecatedValue) {
-      request.headers.set("X-Glean-Exclude-Deprecated-After", deprecatedValue);
+      request.headers.set(EXCLUDE_DEPRECATED_AFTER_HEADER, deprecatedValue);
     }
 
     if (experimentalValue) {
-      request.headers.set("X-Glean-Include-Experimental", experimentalValue);
+      request.headers.set(INCLUDE_EXPERIMENTAL_HEADER, experimentalValue);
     }
 
     return request;

--- a/src/hooks/x-glean.ts
+++ b/src/hooks/x-glean.ts
@@ -64,7 +64,7 @@ export class XGlean implements BeforeRequestHook {
     }
 
     if (experimentalValue) {
-      request.headers.set("X-Glean-Experimental", experimentalValue);
+      request.headers.set("X-Glean-Include-Experimental", experimentalValue);
     }
 
     return request;


### PR DESCRIPTION
## Summary

The `XGlean` `beforeRequest` hook correctly reads the `includeExperimental` SDK option and the `X_GLEAN_INCLUDE_EXPERIMENTAL` env var, but it sets the **wrong header name**. It emits `X-Glean-Experimental` when the backend expects **`X-Glean-Include-Experimental`**.

This corrects the header name in the hook and its tests. Behavior (opt-in via option/env var, env var precedence) is unchanged — only the emitted header name.

## Changes
- `src/hooks/x-glean.ts` — `X-Glean-Experimental` → `X-Glean-Include-Experimental`
- `src/__tests__/x-glean.test.ts` — updated assertions and test descriptions

## Verification
- `npx vitest run src/__tests__/x-glean.test.ts` → 15 passed

## Related
Same bug exists in the Go, Python, and Java SDKs; companion PRs fix each. Env var name (`X_GLEAN_INCLUDE_EXPERIMENTAL`) was already correct and is unchanged.
