### PR TITLE
Preserve snake_case wire field names in generated SDK models

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -116,7 +116,7 @@ typescript:
   outputModelSuffix: output
   packageName: '@gleanwork/api-client'
   preApplyUnionDiscriminators: true
-  preserveModelFieldNames: false
+  preserveModelFieldNames: true
   privateIdentifierPrefix: '#'
   requestExtras: false
   responseFormat: flat


### PR DESCRIPTION
## Summary

The generated TypeScript SDK currently normalizes response field names to camelCase (e.g. the wire returns `agent_id`/`request_id` but the SDK surfaces `agentId`/`requestId`). This causes the SDK response shape to diverge from the raw API response.

This sets `preserveModelFieldNames: true` in `.speakeasy/gen.yaml` so generated models keep the **exact** field names from the OpenAPI spec, matching the raw HTTP response 1:1.

### Why `preserveModelFieldNames` instead of `modelPropertyCasing: snake`
Our API is mixed on the wire — some fields are snake_case (`agent_id`) and some are camelCase (`agentId`). `modelPropertyCasing: snake` would incorrectly rename the genuinely-camel fields. `preserveModelFieldNames: true` preserves each field exactly as sent, so all cases match.

> Note: with `preserveModelFieldNames` enabled, `modelPropertyCasing` only affects synthetic fields (e.g. `additionalProperties`), so it's left as-is.

## Impact
⚠️ **Breaking change** for existing SDK consumers — property access changes (`res.agentId` → `res.agent_id`, etc.). Should ship with a major version bump.

## Scope
TypeScript only. Python already emits snake_case; Go/Java use language-idiomatic casing and don't support this option.