### PR TITLE
Update code owners to team PACT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gleanwork/api-client-reviewers
+* @gleanwork/pact


### PR DESCRIPTION
Updates `.github/CODEOWNERS` to assign ownership to team PACT (`@gleanwork/pact`).